### PR TITLE
Simplifications to IDEA installation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea
+metadata.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@ idea CHANGELOG
 
 This file is used to list changes made in each version of the idea cookbook.
 
-0.1.0
+0.2.2
 -----
-- [your_name] - Initial release of idea
+- Kevin Mellott - Upgraded to install the latest version of IntelliJ IDEA Community (14.1.3) by default. Incorporated the usage of the Ark cookbook to simplify the installation process.
+ Removed the 'user' and 'group' variables, to allow the installation to take place as the default "vagrant" user instead. Removed the "setup_dir" and "ide_dir" variables, and
+ added a desktop entry file. This allows the program to appear in the "Applications" list; tested with Fedora 21.
 
 - - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.

--- a/README.md
+++ b/README.md
@@ -11,16 +11,12 @@ The **default** recipe will:
 Requirements
 ------------
 
-* Depends on **opscode/java** cookbook
+* Depends on **opscode/ark** cookbook
 
 Attributes
 ----------
 
-* `node['idea']['setup_dir']` - Target directory for installation. This cookbook does *not* create `setup_dir` if it does not exist.
-* `node['idea']['user']` - user owner of the installation.
-* `node['idea']['group']` - group owner of the installation (default to the same value as `user` if not specified).
-* `node['idea']['version']` - the version of IntelliJ IDEA to install (default: `14.1.1`).
-* `node['idea']['ide_dir']` - the name of the IDEA folder (default: `idea-IC-{version}`).
+* `node['idea']['version']` - the version of IntelliJ IDEA to install (default: `14.1.3`).
 * `node['idea']['64bits']['Xmx']` - specify the value of `-Xmx` in the 64bits configuration file (default: `2048m`).
 * `node['idea']['64bits']['Xms']` - specify the value of `-Xms` in the 64bits configuration file (default: `2048m`).
 
@@ -30,7 +26,7 @@ Usage
 
 Include `recipe[idea::default]` in your run_list and override the defaults you want changed.
 
-Note: the recipe will not do anything if `node['idea']['setup_dir']` already contains the chosen version of IntelliJ IDEA.
+Note: the recipe will not do anything if IntelliJ IDEA has already been installed and the cookbook has not changed.
 
 Contributing
 ------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-default['idea']['version'] = '14.1.1'
+default['idea']['version'] = '14.1.3'
 default['idea']['64bits']['Xmx'] = '2048m'
 default['idea']['64bits']['Xms'] = '2048m'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'vptheron@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures IntelliJ IDEA'
 long_description 'Please refer to README.md'
-version          '0.2.1'
+version          '0.2.2'
 
 recipe 'idea', 'Downloads, installs and configures IntelliJ IDEA.'
 
-depends "java"
+depends "ark"

--- a/templates/default/idea.desktop.erb
+++ b/templates/default/idea.desktop.erb
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=IntelliJ IDEA Community Edition
+Comment=IntelliJ IDEA Community Edition
+Exec=/usr/local/idea/bin/idea.sh
+Icon=/usr/local/idea/bin/idea.png
+Terminal=false
+Categories=Development;IDE


### PR DESCRIPTION
Upgraded to install the latest version of IntelliJ IDEA Community (14.1.3) by default. Incorporated the usage of the Ark cookbook to simplify the installation process. Removed the 'user' and 'group' variables, to allow the installation to take place as the default "vagrant" user instead. Removed the "setup_dir" and "ide_dir" variables, and added a desktop entry file. This allows the program to appear in the "Applications" list; tested with Fedora 21.