### PR TITLE
Allow configurable download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Attributes
 * `node['idea']['group']` - group owner of the installation (default to the same value as `user` if not specified).
 * `node['idea']['edition']` - Target edition of IntelliJ IDEA to install. Defaults to `C` for Community edition. Other acceptable value: `U` for Ultimate.
 * `node['idea']['version']` - the version of IntelliJ IDEA to install (default: `14.1.4`).
+* `node['idea']['url']` - Download URL for IntelliJ IDEA (default: http://download.jetbrains.com/idea/ideaI#{edition}-#{version}.tar.gz).
 * `node['idea']['ide_dir']` - the name of the IDEA folder (default: `ideaI{edition}-{version}`, e.g. if you install the default version of the Community Edition: `ideaIC-14.1.4`).
 * `node['idea']['64bits']['Xmx']` - specify the value of `-Xmx` in the 64bits configuration file (default: `2048m`).
 * `node['idea']['64bits']['Xms']` - specify the value of `-Xms` in the 64bits configuration file (default: `2048m`).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,3 +24,7 @@ default['idea']['edition'] = 'C'
 default['idea']['64bits']['Xmx'] = '2048m'
 default['idea']['64bits']['Xms'] = '2048m'
 
+edition = node['idea']['edition']
+version = node['idea']['version']
+
+default['idea']['url'] = "http://download.jetbrains.com/idea/ideaI#{edition}-#{version}.tar.gz"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,8 @@ group = node['idea']['group'] || user
 edition = node['idea']['edition']
 version = node['idea']['version']
 
+url = node['idea']['url']
+
 setup_dir = node['idea']['setup_dir']
 ide_dir = node['idea']['ide_dir'] || "idea-I#{edition}-#{version}"
 
@@ -35,7 +37,7 @@ if !::File.exists?("#{install_path}")
 
   # Download IDEA archive
   remote_file archive_path do 
-    source "http://download.jetbrains.com/idea/ideaI#{edition}-#{version}.tar.gz"
+    source url
   end
 
   # Extract archive


### PR DESCRIPTION
This allows for local mirroring, since upstream removes versions from availability.