### PR TITLE
Missed an end, causing failures when running the recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,6 +63,7 @@ unless ::File.exist?(install_path)
   file archive_path do
     action :delete
   end
+end
 
 # .desktop entry
 template '/usr/share/applications/idea.desktop' do


### PR DESCRIPTION
Otherwise, we fail at compilation.