### PR TITLE
Use the full edition name in the Desktop entry

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,12 +65,19 @@ unless ::File.exist?(install_path)
   end
 end
 
+full_edition =
+  if node['idea']['edition'] == 'U'
+    'Ultimate'
+  else
+    'Community'
+  end
+
 # .desktop entry
 template '/usr/share/applications/idea.desktop' do
   source 'idea.desktop.erb'
   variables(
     setup_dir,
-    edition
+    full_edition
   )
   action :create
 end

--- a/templates/default/idea.desktop.erb
+++ b/templates/default/idea.desktop.erb
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=IntelliJ IDEA <%= @edition.capitalize %> Edition
-Comment=IntelliJ IDEA <%= @edition.capitalize %> Edition
+Name=IntelliJ IDEA <%= @full_edition %> Edition
+Comment=IntelliJ IDEA <%= @full_edition %> Edition
 Exec=<%= @setup_dir %>/idea/bin/idea.sh
 Icon=<%= @setup_dir %>/idea/bin/idea.png
 Terminal=false


### PR DESCRIPTION
This will use the full `Ultimate` or `Community` edition labels, versus only `U` or `C`