### PR TITLE
Version bump to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 idea CHANGELOG
 ==============
 
-This file is used to list changes made in each version of the idea cookbook.
-
-0.1.0
+0.6.0
 -----
-- [your_name] - Initial release of idea
+- Rewrite IDEA installation ( Issues: #2 #8 #9 #10 #11 #12 )
+- Minor style fixes ( Issue: #7 )
+- Add cookbook testing framework ( Issue: #13 )
+- Update default version to latest ( Issues: #14 #15 )
 
-- - -
-Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
-
-The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.
+Changes for versions prior to 0.6.0 can be obtained via [GitHub](https://github.com/vptheron/chef-idea/releases)

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ gem 'berkshelf', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+if RUBY_VERSION.to_f < 2.2
+  gem 'fauxhai', '< 3.10'
+  gem 'rack', '< 2.0'
+end
+
 if RUBY_VERSION.to_f < 2.1
   gem 'buff-ignore', '< 1.2'
   gem 'chef-zero', '< 4.6'
@@ -25,7 +30,6 @@ else
   gem 'rubocop'
 end
 
-gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
 gem 'rainbow', '<= 1.99.1'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Attributes
 * `node['idea']['user']` - user owner of the installation.
 * `node['idea']['group']` - group owner of the installation (default to the same value as `user` if not specified).
 * `node['idea']['edition']` - Target edition of IntelliJ IDEA to install. Defaults to `C` for Community edition. Other acceptable value: `U` for Ultimate.
-* `node['idea']['version']` - the version of IntelliJ IDEA to install (default: `2016.2.3`).
+* `node['idea']['version']` - the version of IntelliJ IDEA to install (default: `2016.2.5`).
 * `node['idea']['url']` - Download URL for IntelliJ IDEA (default: `https://download-cf.jetbrains.com/idea/ideaI#{edition}-#{version}.tar.gz`).
 * `node['idea']['64bits']['Xmx']` - specify the value of `-Xmx` in the 64bits configuration file (default: `2048m`).
 * `node['idea']['64bits']['Xms']` - specify the value of `-Xms` in the 64bits configuration file (default: `2048m`).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-default['idea']['version'] = '2016.2.4'
+default['idea']['version'] = '2016.2.5'
 default['idea']['edition'] = 'C'
 default['idea']['64bits']['Xmx'] = '2048m'
 default['idea']['64bits']['Xms'] = '2048m'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'vptheron@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures IntelliJ IDEA'
 long_description 'Please refer to README.md'
-version          '0.6.0-SNAPSHOT'
+version          '0.6.0'
 
 recipe 'idea::default', 'Downloads, installs and configures IntelliJ IDEA.'
 


### PR DESCRIPTION
This updates us to the latest IDEA version, updates the CHANGELOG.md, and removes SNAPSHOT from the version.

@vptheron could you merge this and then push a new release to Chef Supermarket?